### PR TITLE
Fix/tims response

### DIFF
--- a/tims_tevin_typec_integration/tims_tevic_type_c_integration/overrides/server/delivery_note.py
+++ b/tims_tevin_typec_integration/tims_tevic_type_c_integration/overrides/server/delivery_note.py
@@ -26,7 +26,8 @@ def before_save(doc, method=None):
 def before_save_sales_invoice(doc, method=None):
     get_hs_code_before_save(doc)
     if doc.is_return==1:
-        calculate_tax(doc)
+        return
+    calculate_tax(doc)
     
 
 def get_hs_code_before_save(doc):

--- a/tims_tevin_typec_integration/tims_tevic_type_c_integration/overrides/server/sales_invoice.py
+++ b/tims_tevin_typec_integration/tims_tevic_type_c_integration/overrides/server/sales_invoice.py
@@ -292,10 +292,6 @@ def make_tims_request(
         invoice = invoice_info["TraderSystemInvoiceNumber"]
 
         sales_invoice = update_integration_request(integration_request, "Completed", response.json())
-        
-        print('-------------------------------')
-        print(sales_invoice)
-
         qr_code = get_qr_code(invoice_info["QRCode"])
         
         '''Change the prefix to CN- if the invoice is a credit note'''

--- a/tims_tevin_typec_integration/tims_tevic_type_c_integration/overrides/server/sales_invoice.py
+++ b/tims_tevin_typec_integration/tims_tevic_type_c_integration/overrides/server/sales_invoice.py
@@ -145,8 +145,8 @@ def build_item_details(doc, tax_rate) -> list[dict]:
             })
         else:
             item_data.update({
-                "TaxRate": item.custom_tax_rate,
-                "TaxAmount": abs(item.custom_tax_amount),
+                "TaxRate": float(item.custom_tax_rate),
+                "TaxAmount": abs(float(item.custom_tax_amount)),
             })
         
         item_details.append(item_data)
@@ -270,6 +270,8 @@ def update_integration_request(
     doc.output = str(output)
 
     doc.save(ignore_permissions=True)
+    
+    return doc.reference_docname
 
 
 def make_tims_request(
@@ -289,7 +291,10 @@ def make_tims_request(
             invoice_info = response.json()["Existing"]
         invoice = invoice_info["TraderSystemInvoiceNumber"]
 
-        update_integration_request(integration_request, "Completed", response.json())
+        sales_invoice = update_integration_request(integration_request, "Completed", response.json())
+        
+        print('-------------------------------')
+        print(sales_invoice)
 
         qr_code = get_qr_code(invoice_info["QRCode"])
         
@@ -299,13 +304,16 @@ def make_tims_request(
 
         frappe.db.set_value(
             "Sales Invoice",
-            invoice_number,
+            sales_invoice,
             {
                 "custom_cu_invoice_number": invoice_info["ControlCode"],
                 "custom_qr_code": qr_code,
             },
             update_modified=True,
         )
+        
+        
+        frappe.db.commit()
         '''If you decide to go with the custom_delivery_note_no field, uncomment the code below'''
         # invoice_name=frappe.db.get_value("Sales Invoice",{"custom_delivery_note_no":invoice},"name")
         # frappe.db.set_value(


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the `sales_invoice.py` and `delivery_note.py` server override files, focusing on data type consistency, return value handling, and database updates. The most important changes improve reliability when handling tax values and ensure correct invoice references are used during integration with external systems.

**Data consistency and reliability improvements:**

* Ensured that `TaxRate` and `TaxAmount` fields in the item details are always stored as floats for better data consistency (`build_item_details` in `sales_invoice.py`).

**Integration and workflow enhancements:**

* Modified `update_integration_request` to return the invoice reference name, allowing downstream functions to use the correct invoice identifier.
* Updated `make_tims_request` to use the returned invoice name from `update_integration_request` when updating the database, ensuring the correct invoice is updated and committed. Added debug print statements for traceability. [[1]](diffhunk://#diff-3d56cab2c55256c1dc92d621e8ed12978ddee7b85ca65ebca8e0290bed651de7L292-R297) [[2]](diffhunk://#diff-3d56cab2c55256c1dc92d621e8ed12978ddee7b85ca65ebca8e0290bed651de7L302-R316)

**Bug fix:**

* Fixed the workflow in `before_save_sales_invoice` to skip tax calculation when the invoice is a return, preventing unnecessary processing. (`delivery_note.py`)