### PR TITLE
Fix/tims response

### DIFF
--- a/tims_tevin_typec_integration/tims_tevic_type_c_integration/overrides/server/delivery_note.py
+++ b/tims_tevin_typec_integration/tims_tevic_type_c_integration/overrides/server/delivery_note.py
@@ -26,7 +26,8 @@ def before_save(doc, method=None):
 def before_save_sales_invoice(doc, method=None):
     get_hs_code_before_save(doc)
     if doc.is_return==1:
-        calculate_tax(doc)
+        return
+    calculate_tax(doc)
     
 
 def get_hs_code_before_save(doc):

--- a/tims_tevin_typec_integration/tims_tevic_type_c_integration/overrides/server/sales_invoice.py
+++ b/tims_tevin_typec_integration/tims_tevic_type_c_integration/overrides/server/sales_invoice.py
@@ -292,10 +292,6 @@ def make_tims_request(
         invoice = invoice_info["TraderSystemInvoiceNumber"]
 
         sales_invoice = update_integration_request(integration_request, "Completed", response.json())
-        
-        print('-------------------------------')
-        print(sales_invoice)
-
         qr_code = get_qr_code(invoice_info["QRCode"])
         
         '''Change the prefix to CN- if the invoice is a credit note'''

--- a/tims_tevin_typec_integration/tims_tevic_type_c_integration/overrides/server/sales_invoice.py
+++ b/tims_tevin_typec_integration/tims_tevic_type_c_integration/overrides/server/sales_invoice.py
@@ -145,8 +145,8 @@ def build_item_details(doc, tax_rate) -> list[dict]:
             })
         else:
             item_data.update({
-                "TaxRate": item.custom_tax_rate,
-                "TaxAmount": abs(item.custom_tax_amount),
+                "TaxRate": float(item.custom_tax_rate),
+                "TaxAmount": abs(float(item.custom_tax_amount)),
             })
         
         item_details.append(item_data)
@@ -270,6 +270,8 @@ def update_integration_request(
     doc.output = str(output)
 
     doc.save(ignore_permissions=True)
+    
+    return doc.reference_docname
 
 
 def make_tims_request(
@@ -289,7 +291,10 @@ def make_tims_request(
             invoice_info = response.json()["Existing"]
         invoice = invoice_info["TraderSystemInvoiceNumber"]
 
-        update_integration_request(integration_request, "Completed", response.json())
+        sales_invoice = update_integration_request(integration_request, "Completed", response.json())
+        
+        print('-------------------------------')
+        print(sales_invoice)
 
         qr_code = get_qr_code(invoice_info["QRCode"])
         
@@ -299,13 +304,16 @@ def make_tims_request(
 
         frappe.db.set_value(
             "Sales Invoice",
-            invoice_number,
+            sales_invoice,
             {
                 "custom_cu_invoice_number": invoice_info["ControlCode"],
                 "custom_qr_code": qr_code,
             },
             update_modified=True,
         )
+        
+        
+        frappe.db.commit()
         '''If you decide to go with the custom_delivery_note_no field, uncomment the code below'''
         # invoice_name=frappe.db.get_value("Sales Invoice",{"custom_delivery_note_no":invoice},"name")
         # frappe.db.set_value(


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the sales invoice integration logic, focusing on type safety, return handling, and ensuring database consistency. The most important changes are grouped below:

**Bug Fixes and Logic Improvements:**

* The `before_save_sales_invoice` function now immediately returns if the document is a return, preventing unnecessary tax calculations in such cases.

**Type Safety and Data Consistency:**

* In `build_item_details`, both `TaxRate` and `TaxAmount` are now explicitly cast to floats, ensuring type consistency and preventing potential errors when processing item data.

**Integration Request Handling:**

* The `update_integration_request` function now returns the document's reference name after saving, enabling downstream processes to reliably identify the updated document.
* The `make_tims_request` function now uses the returned reference name from `update_integration_request` to update the correct sales invoice record, improving accuracy in database updates. [[1]](diffhunk://#diff-3d56cab2c55256c1dc92d621e8ed12978ddee7b85ca65ebca8e0290bed651de7L292-R294) [[2]](diffhunk://#diff-3d56cab2c55256c1dc92d621e8ed12978ddee7b85ca65ebca8e0290bed651de7L302-R312)
* After updating the sales invoice with new values, a database commit is explicitly performed to ensure changes are persisted immediately.