### PR TITLE
fix: Update tax calculation logic in before_save_sales_invoice and reference doc name for paylod

### DIFF
--- a/tims_tevin_typec_integration/tims_tevic_type_c_integration/overrides/server/delivery_note.py
+++ b/tims_tevin_typec_integration/tims_tevic_type_c_integration/overrides/server/delivery_note.py
@@ -26,7 +26,8 @@ def before_save(doc, method=None):
 def before_save_sales_invoice(doc, method=None):
     get_hs_code_before_save(doc)
     if doc.is_return==1:
-        calculate_tax(doc)
+        return
+    calculate_tax(doc)
     
 
 def get_hs_code_before_save(doc):

--- a/tims_tevin_typec_integration/tims_tevic_type_c_integration/overrides/server/sales_invoice.py
+++ b/tims_tevin_typec_integration/tims_tevic_type_c_integration/overrides/server/sales_invoice.py
@@ -187,7 +187,7 @@ def build_payload(doc, setting, invoice_category, relevant_invoice_number, item_
     return {
         "Invoice": {
             "SenderId": setting.sender_id,
-            "TraderSystemInvoiceNumber": trader_invoice_no,
+            "TraderSystemInvoiceNumber": doc.name,
             "InvoiceCategory": invoice_category,
             "InvoiceTimestamp": f"{doc.posting_date}T{posting_time}",
             "RelevantInvoiceNumber": relevant_invoice_number,


### PR DESCRIPTION


**Integration Payload Construction:**
* Modified the payload builder in `build_payload` to use `doc.name` as the `TraderSystemInvoiceNumber` instead of the previously used `trader_invoice_no`, ensuring consistency and correctness in the invoice number sent to external systems.