### PR TITLE
Fix/tims response

### DIFF
--- a/tims_tevin_typec_integration/tims_tevic_type_c_integration/doctype/tims_settings/tims_settings.json
+++ b/tims_tevin_typec_integration/tims_tevic_type_c_integration/doctype/tims_settings/tims_settings.json
@@ -1,170 +1,179 @@
 {
-  "actions": [],
-  "allow_rename": 1,
-  "autoname": "hash",
-  "creation": "2024-09-20 14:24:41.006213",
-  "description": "Settings doctype for TIMS Tevin Type-C device",
-  "doctype": "DocType",
-  "engine": "InnoDB",
-  "field_order": [
-    "credentials_tab",
-    "company",
-    "sender_id",
-    "cusn",
-    "column_break_atws",
-    "server_address",
-    "branch_id",
-    "is_active",
-    "miscellaneous_tab",
-    "background_jobs_configuration_section",
-    "eod_fetch_frequency",
-    "eod_cron",
-    "column_break_gwof",
-    "flush_email_frequency",
-    "flush_email_cron",
-    "column_break_jmvd",
-    "resend_invoices_frequency",
-    "resend_invoices_cron"
-  ],
-  "fields": [
-    {
-      "fieldname": "sender_id",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "in_standard_filter": 1,
-      "label": "Sender ID",
-      "reqd": 1,
-      "unique": 1
-    },
-    {
-      "fieldname": "column_break_atws",
-      "fieldtype": "Column Break"
-    },
-    {
-      "description": "This is the address of the TIMS Device. Format: hostname:port",
-      "fieldname": "server_address",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "in_standard_filter": 1,
-      "label": "Server Address",
-      "reqd": 1,
-      "unique": 1
-    },
-    {
-      "description": "This is the company associated with this TIMS Setting.",
-      "fieldname": "company",
-      "fieldtype": "Link",
-      "label": "Company",
-      "options": "Company",
-      "reqd": 1
-    },
-    {
-      "fieldname": "cusn",
-      "fieldtype": "Data",
-      "label": "CUSN",
-      "unique": 1
-    },
-    {
-      "fieldname": "branch_id",
-      "fieldtype": "Data",
-      "label": "Branch ID",
-      "unique": 1
-    },
-    {
-      "fieldname": "credentials_tab",
-      "fieldtype": "Tab Break",
-      "label": "Credentials"
-    },
-    {
-      "fieldname": "miscellaneous_tab",
-      "fieldtype": "Tab Break",
-      "label": "Miscellaneous"
-    },
-    {
-      "default": "Daily",
-      "fieldname": "eod_fetch_frequency",
-      "fieldtype": "Select",
-      "label": "EOD Fetch Frequency",
-      "options": "\nDaily\nCron"
-    },
-    {
-      "depends_on": "eval:(doc.eod_fetch_frequency === \"Cron\");",
-      "fieldname": "eod_cron",
-      "fieldtype": "Data",
-      "label": "EOD Fetch Cron Expression",
-      "mandatory_depends_on": "eval:(doc.eod_fetch_frequency === \"Cron\");"
-    },
-    {
-      "fieldname": "column_break_gwof",
-      "fieldtype": "Column Break"
-    },
-    {
-      "default": "All",
-      "fieldname": "flush_email_frequency",
-      "fieldtype": "Select",
-      "label": "Flush Email Frequency",
-      "options": "\nAll\nHourly\nCron"
-    },
-    {
-      "depends_on": "eval:(doc.flush_email_frequency === \"Cron\");",
-      "fieldname": "flush_email_cron",
-      "fieldtype": "Data",
-      "label": "Flush Email Cron Expression",
-      "mandatory_depends_on": "eval:(doc.flush_email_frequency === \"Cron\");"
-    },
-    {
-      "fieldname": "column_break_jmvd",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "resend_invoices_frequency",
-      "fieldtype": "Select",
-      "label": "Resend Failed Invoices Frequency",
-      "options": "\nAll\nHourly\nDaily\nCron"
-    },
-    {
-      "depends_on": "eval:(doc.resend_invoices_frequency === \"Cron\")",
-      "fieldname": "resend_invoices_cron",
-      "fieldtype": "Data",
-      "label": "Resend Failed Invoices Cron Expression",
-      "mandatory_depends_on": "eval:(doc.resend_invoices_frequency === \"Cron\")"
-    },
-    {
-      "fieldname": "background_jobs_configuration_section",
-      "fieldtype": "Section Break",
-      "label": "Background Jobs Frequency Configuration"
-    },
-    {
-      "default": "1",
-      "fieldname": "is_active",
-      "fieldtype": "Check",
-      "label": "Is Active?"
-    }
-  ],
-  "index_web_pages_for_search": 1,
-  "links": [],
-  "modified": "2024-10-03 09:03:29.272396",
-  "modified_by": "Administrator",
-  "module": "TIMS Tevic Type-C Integration",
-  "name": "TIMS Settings",
-  "naming_rule": "Random",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "System Manager",
-      "share": 1,
-      "write": 1
-    }
-  ],
-  "sort_field": "modified",
-  "sort_order": "DESC",
-  "states": [],
-  "track_changes": 1
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "hash",
+ "creation": "2024-09-20 14:24:41.006213",
+ "description": "Settings doctype for TIMS Tevin Type-C device",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "credentials_tab",
+  "company",
+  "sender_id",
+  "cusn",
+  "column_break_atws",
+  "server_address",
+  "branch_id",
+  "individual_item_taxes",
+  "is_active",
+  "miscellaneous_tab",
+  "background_jobs_configuration_section",
+  "eod_fetch_frequency",
+  "eod_cron",
+  "column_break_gwof",
+  "flush_email_frequency",
+  "flush_email_cron",
+  "column_break_jmvd",
+  "resend_invoices_frequency",
+  "resend_invoices_cron"
+ ],
+ "fields": [
+  {
+   "fieldname": "sender_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Sender ID",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "column_break_atws",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "This is the address of the TIMS Device. Format: hostname:port",
+   "fieldname": "server_address",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Server Address",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "description": "This is the company associated with this TIMS Setting.",
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
+  },
+  {
+   "fieldname": "cusn",
+   "fieldtype": "Data",
+   "label": "CUSN",
+   "unique": 1
+  },
+  {
+   "fieldname": "branch_id",
+   "fieldtype": "Data",
+   "label": "Branch ID",
+   "unique": 1
+  },
+  {
+   "fieldname": "credentials_tab",
+   "fieldtype": "Tab Break",
+   "label": "Credentials"
+  },
+  {
+   "fieldname": "miscellaneous_tab",
+   "fieldtype": "Tab Break",
+   "label": "Miscellaneous"
+  },
+  {
+   "default": "Daily",
+   "fieldname": "eod_fetch_frequency",
+   "fieldtype": "Select",
+   "label": "EOD Fetch Frequency",
+   "options": "\nDaily\nCron"
+  },
+  {
+   "depends_on": "eval:(doc.eod_fetch_frequency === \"Cron\");",
+   "fieldname": "eod_cron",
+   "fieldtype": "Data",
+   "label": "EOD Fetch Cron Expression",
+   "mandatory_depends_on": "eval:(doc.eod_fetch_frequency === \"Cron\");"
+  },
+  {
+   "fieldname": "column_break_gwof",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "All",
+   "fieldname": "flush_email_frequency",
+   "fieldtype": "Select",
+   "label": "Flush Email Frequency",
+   "options": "\nAll\nHourly\nCron"
+  },
+  {
+   "depends_on": "eval:(doc.flush_email_frequency === \"Cron\");",
+   "fieldname": "flush_email_cron",
+   "fieldtype": "Data",
+   "label": "Flush Email Cron Expression",
+   "mandatory_depends_on": "eval:(doc.flush_email_frequency === \"Cron\");"
+  },
+  {
+   "fieldname": "column_break_jmvd",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "resend_invoices_frequency",
+   "fieldtype": "Select",
+   "label": "Resend Failed Invoices Frequency",
+   "options": "\nAll\nHourly\nDaily\nCron"
+  },
+  {
+   "depends_on": "eval:(doc.resend_invoices_frequency === \"Cron\")",
+   "fieldname": "resend_invoices_cron",
+   "fieldtype": "Data",
+   "label": "Resend Failed Invoices Cron Expression",
+   "mandatory_depends_on": "eval:(doc.resend_invoices_frequency === \"Cron\")"
+  },
+  {
+   "fieldname": "background_jobs_configuration_section",
+   "fieldtype": "Section Break",
+   "label": "Background Jobs Frequency Configuration"
+  },
+  {
+   "default": "1",
+   "fieldname": "is_active",
+   "fieldtype": "Check",
+   "label": "Is Active?"
+  },
+  {
+   "default": "0",
+   "description": "Enable to apply tax rates from individual Item Tax Templates for each line item. Disable to apply the same tax rate from Sales Taxes and Charges to all items ",
+   "fieldname": "individual_item_taxes",
+   "fieldtype": "Check",
+   "label": "Apply Individual Item Taxes"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-01-11 23:30:36.988068",
+ "modified_by": "Administrator",
+ "module": "TIMS Tevic Type-C Integration",
+ "name": "TIMS Settings",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
 }

--- a/tims_tevin_typec_integration/tims_tevic_type_c_integration/overrides/server/delivery_note.py
+++ b/tims_tevin_typec_integration/tims_tevic_type_c_integration/overrides/server/delivery_note.py
@@ -1,16 +1,38 @@
 
 import frappe
 def calculate_tax(doc):
-    tax_rate = items_tax_fields(doc)
-    for item in doc.items:
-        tax = 0
-        if tax_rate:
-            tax = item.net_amount * tax_rate / 100
-        item.custom_tax_amount = tax
-        item.custom_tax_rate = tax_rate
-    
+    tims_settings = get_tims_settings(doc)
+    if tims_settings and tims_settings.get("individual_item_taxes"):
+        for item in doc.items:
+            tax_rate = get_item_tax_rate(item)
+            append_tax_rate_to_item(tax_rate, item)
+    elif tims_settings and not tims_settings.get("individual_item_taxes"):
+        tax_rate = items_tax_fields(doc)
+        for item in doc.items:
+            append_tax_rate_to_item(tax_rate, item)
+        
     else:
         return 0
+    
+
+def append_tax_rate_to_item(tax_rate, item):
+    tax = 0
+    if tax_rate:
+        tax = item.net_amount * tax_rate / 100
+    item.custom_tax_amount = tax
+    item.custom_tax_rate = tax_rate
+
+
+def get_item_tax_rate(item):
+
+    item = frappe.get_doc("Item", item.item_code)
+    if item.taxes:
+        item_tax_template = item.taxes[0].item_tax_template
+
+    item_tax_template_doc = frappe.get_doc("Item Tax Template", item_tax_template)
+    if item_tax_template_doc.taxes:
+        return item_tax_template_doc.taxes[0].tax_rate
+        
     
 def items_tax_fields(doc):
     taxes_template = doc.taxes_and_charges
@@ -19,7 +41,17 @@ def items_tax_fields(doc):
         return tax_template.taxes[0].rate
     else:
         return None
-    
+
+def get_tims_settings(doc) -> dict | None:
+    """Get TIMS settings for the company"""
+    company = frappe.defaults.get_user_default("Company")
+    return frappe.db.get_value(
+        "TIMS Settings",
+        {"company": company, "is_active": 1},
+        ["server_address", "sender_id","individual_item_taxes"],
+        as_dict=True,
+    )
+
 def before_save(doc, method=None):
     calculate_tax(doc)
     


### PR DESCRIPTION
This pull request introduces a new feature allowing taxes to be applied to each line item individually based on their Item Tax Template, rather than using a single tax rate for all items. This is controlled by a new setting in the `TIMS Settings` doctype. The implementation includes changes to both the settings JSON and the tax calculation logic in the delivery note override.

**Feature: Individual Item Taxes Support**

* Added a new `individual_item_taxes` checkbox field to the `TIMS Settings` doctype, enabling users to choose whether to apply tax rates from individual Item Tax Templates per line item or use a uniform tax rate for all items. [[1]](diffhunk://#diff-34c652c92cf2594d7e9aa63b4179cd0a76f0c3249ebcd02544e6bfc5e888ab88R17) [[2]](diffhunk://#diff-34c652c92cf2594d7e9aa63b4179cd0a76f0c3249ebcd02544e6bfc5e888ab88R143-R154)
* Updated the tax calculation logic in `delivery_note.py` to check the new setting and, if enabled, apply taxes per item based on their respective Item Tax Templates.
* Added helper methods: `get_tims_settings` to fetch the relevant settings for the current company, and `get_item_tax_rate` to retrieve the tax rate from an item's tax template. [[1]](diffhunk://#diff-bc9746cfadb1c4a51d42acfc99bf6fb7b149684e3184a6a195ca93fed749d0dbR45-R54) [[2]](diffhunk://#diff-bc9746cfadb1c4a51d42acfc99bf6fb7b149684e3184a6a195ca93fed749d0dbR4-R35)

**Configuration and Metadata Updates**

* Set `row_format` to `Dynamic` in the `TIMS Settings` JSON to enhance UI flexibility.