### PR TITLE
Add custom tax calculation logic supporting item-level and document-level taxes

### DIFF
--- a/tims_tevin_typec_integration/tims_tevic_type_c_integration/doctype/tims_settings/tims_settings.json
+++ b/tims_tevin_typec_integration/tims_tevic_type_c_integration/doctype/tims_settings/tims_settings.json
@@ -14,7 +14,6 @@
   "column_break_atws",
   "server_address",
   "branch_id",
-  "individual_item_taxes",
   "is_active",
   "miscellaneous_tab",
   "background_jobs_configuration_section",
@@ -140,18 +139,11 @@
    "fieldname": "is_active",
    "fieldtype": "Check",
    "label": "Is Active?"
-  },
-  {
-   "default": "0",
-   "description": "Enable to apply tax rates from individual Item Tax Templates for each line item. Disable to apply the same tax rate from Sales Taxes and Charges to all items ",
-   "fieldname": "individual_item_taxes",
-   "fieldtype": "Check",
-   "label": "Apply Individual Item Taxes"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-11 23:30:36.988068",
+ "modified": "2026-01-15 08:37:01.388277",
  "modified_by": "Administrator",
  "module": "TIMS Tevic Type-C Integration",
  "name": "TIMS Settings",

--- a/tims_tevin_typec_integration/tims_tevic_type_c_integration/overrides/server/delivery_note.py
+++ b/tims_tevin_typec_integration/tims_tevic_type_c_integration/overrides/server/delivery_note.py
@@ -1,19 +1,40 @@
-
 import frappe
-def calculate_tax(doc):
-    tims_settings = get_tims_settings(doc)
-    if tims_settings and tims_settings.get("individual_item_taxes"):
-        for item in doc.items:
-            tax_rate = get_item_tax_rate(item)
-            append_tax_rate_to_item(tax_rate, item)
-    elif tims_settings and not tims_settings.get("individual_item_taxes"):
-        tax_rate = items_tax_fields(doc)
-        for item in doc.items:
-            append_tax_rate_to_item(tax_rate, item)
-        
+from frappe.model.document import Document
+
+
+def calculate_tax(doc: Document):
+
+    taxes = doc.get("taxes", [])
+    has_item_level_taxes = any(item.item_tax_template for item in doc.items)
+
+    if has_item_level_taxes:
+        calculate_item_level_taxes(doc)
+
+    elif taxes:
+        calculate_document_level_taxes(doc)
+
+
+def calculate_document_level_taxes(doc: Document):
+    tax_rate = items_tax_fields(doc)
+    for item in doc.items:
+        append_tax_rate_to_item(tax_rate, item)
+
+
+def calculate_item_level_taxes(doc: Document):
+
+    for item in doc.items:
+        tax_rate = get_item_tax_rate(item.item_tax_template)
+        append_tax_rate_to_item(tax_rate, item)
+
+
+def get_item_tax_rate(item_tax_template):
+
+    item_tax_template_doc = frappe.get_doc("Item Tax Template", item_tax_template)
+    if item_tax_template_doc.taxes:
+        return item_tax_template_doc.taxes[0].tax_rate
     else:
         return 0
-    
+
 
 def append_tax_rate_to_item(tax_rate, item):
     tax = 0
@@ -23,18 +44,7 @@ def append_tax_rate_to_item(tax_rate, item):
     item.custom_tax_rate = tax_rate
 
 
-def get_item_tax_rate(item):
-
-    item = frappe.get_doc("Item", item.item_code)
-    if item.taxes:
-        item_tax_template = item.taxes[0].item_tax_template
-
-    item_tax_template_doc = frappe.get_doc("Item Tax Template", item_tax_template)
-    if item_tax_template_doc.taxes:
-        return item_tax_template_doc.taxes[0].tax_rate
-        
-    
-def items_tax_fields(doc):
+def items_tax_fields(doc: Document):
     taxes_template = doc.taxes_and_charges
     tax_template = frappe.get_doc("Sales Taxes and Charges Template", taxes_template)
     if tax_template.taxes:
@@ -42,31 +52,23 @@ def items_tax_fields(doc):
     else:
         return None
 
-def get_tims_settings(doc) -> dict | None:
-    """Get TIMS settings for the company"""
-    company = frappe.defaults.get_user_default("Company")
-    return frappe.db.get_value(
-        "TIMS Settings",
-        {"company": company, "is_active": 1},
-        ["server_address", "sender_id","individual_item_taxes"],
-        as_dict=True,
-    )
 
 def before_save(doc, method=None):
     calculate_tax(doc)
-    
+
+
 def before_save_sales_invoice(doc, method=None):
     get_hs_code_before_save(doc)
-    if doc.is_return==1:
+    if doc.is_return == 1:
         return
     calculate_tax(doc)
-    
+
 
 def get_hs_code_before_save(doc):
     for item in doc.items:
         hs_code = get_hs_code_item_tax(item.item_code, item.item_tax_template)
         item.custom_hs_code = hs_code or ""
-        
+
 
 def get_hs_code_item_tax(item_code, item_tax_template_name=None):
     """
@@ -79,22 +81,24 @@ def get_hs_code_item_tax(item_code, item_tax_template_name=None):
 
     if item_tax_template_name:
         tax_row = frappe.db.get_value(
-            "Item Tax",
-            {"item_tax_template": item_tax_template_name},
-            ["tims_hscode"]
+            "Item Tax", {"item_tax_template": item_tax_template_name}, ["tims_hscode"]
         )
         if tax_row:
             return tax_row
 
     # Fallback: Get first Item Tax record for item
-    item_tax = frappe.get_all("Item Tax", filters={"parent": item_code}, fields=["tims_hscode"], limit=1)
+    item_tax = frappe.get_all(
+        "Item Tax", filters={"parent": item_code}, fields=["tims_hscode"], limit=1
+    )
     if item_tax and item_tax[0].tims_hscode:
         return item_tax[0].tims_hscode
 
     # Fallback: Get item group tax template
     item_doc = frappe.get_doc("Item", item_code)
     item_group = item_doc.item_group
-    group_tax = frappe.get_all("Item Tax", filters={"parent": item_group}, fields=["tims_hscode"], limit=1)
+    group_tax = frappe.get_all(
+        "Item Tax", filters={"parent": item_group}, fields=["tims_hscode"], limit=1
+    )
     if group_tax and group_tax[0].tims_hscode:
         return group_tax[0].tims_hscode
 


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the TIMS Tevic Type-C Integration, focusing on tax calculation logic, error handling, and code readability. The most notable changes include a major refactor of the tax calculation logic for delivery notes, improved error handling and validation for TIMS settings, and various formatting and code cleanup updates to enhance maintainability.

**Tax Calculation Refactor and Enhancements:**

* Detects whether the document uses **item-level tax templates** or **document-level taxes**
* Applies tax rates accordingly:

  * **Item-level**: Uses each item’s `Item Tax Template`
  * **Document-level**: Uses the `Sales Taxes and Charges Template`
* Calculates tax as a percentage of `item.net_amount`
* Stores results on item fields:

  * `custom_tax_rate`
  * `custom_tax_amount`

## How it works

1. `calculate_tax`

   * Checks if any item has an `item_tax_template`
   * Routes calculation to item-level or document-level logic

2. Item-level tax calculation

   * Fetches tax rate from `Item Tax Template`
   * Applies the rate per item

3. Document-level tax calculation

   * Fetches the first tax rate from `Sales Taxes and Charges Template`
   * Applies the same rate to all items



**Error Handling and Validation:**

- Updated the `on_submit` function in `sales_invoice.py` to throw an explicit error if TIMS settings are missing, ensuring users are notified to set up the required configuration.
